### PR TITLE
Support non-default pulse settings

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,11 +27,16 @@ func NewClient() (*Client, error) {
 	socketPath := fmt.Sprint("/run/user/", os.Getuid(), "/pulse/native")
 	if pathRaw, ok := os.LookupEnv("PULSE_SERVER"); ok {
 		path := strings.SplitN(pathRaw, ":", 2)
-		if len(path) != 2 {
-			return nil, errors.New("no network type in PULSE_SERVER")
+		switch len(path) {
+		case 1:
+			// If the network type is not specified, it should be handled as unix socket.
+			socketPath = path[0]
+		case 2:
+			socketNetwork = path[0]
+			socketPath = path[1]
+		default:
+			return nil, errors.New("invalid PULSE_SERVER string")
 		}
-		socketNetwork = path[0]
-		socketPath = path[1]
 	}
 
 	conn, err := net.Dial(socketNetwork, socketPath)

--- a/client.go
+++ b/client.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"path"
-	"strings"
 	"sync"
 
 	"github.com/jfreymuth/pulse/proto"
@@ -23,92 +22,105 @@ type Client struct {
 }
 
 func NewClient() (*Client, error) {
-	socketNetwork := "unix"
-	socketPath := fmt.Sprint("/run/user/", os.Getuid(), "/pulse/native")
-	if pathRaw, ok := os.LookupEnv("PULSE_SERVER"); ok {
-		path := strings.SplitN(pathRaw, ":", 2)
-		switch len(path) {
-		case 1:
-			// If the network type is not specified, it should be handled as unix socket.
-			socketPath = path[0]
-		case 2:
-			socketNetwork = path[0]
-			socketPath = path[1]
-		default:
-			return nil, errors.New("invalid PULSE_SERVER string")
+	servers := []serverString{
+		{
+			protocol: "unix",
+			addr:     fmt.Sprint("/run/user/", os.Getuid(), "/pulse/native"),
+		},
+	}
+	if serverRaw, ok := os.LookupEnv("PULSE_SERVER"); ok {
+		servers = parseServerString(serverRaw)
+		if len(servers) == 0 {
+			return nil, errors.New("no valid pulse server")
 		}
 	}
 
-	conn, err := net.Dial(socketNetwork, socketPath)
+	localname, err := os.Hostname()
 	if err != nil {
 		return nil, err
 	}
 
-	c := &Client{conn: conn}
-	c.playback = make(map[uint32]*PlaybackStream)
-	c.record = make(map[uint32]*RecordStream)
-	c.c.Callback = func(msg interface{}) {
-		switch msg := msg.(type) {
-		case *proto.Request:
-			c.mu.Lock()
-			stream, ok := c.playback[msg.StreamIndex]
-			c.mu.Unlock()
-			if ok {
-				c.c.Send(msg.StreamIndex, stream.buffer(int(msg.Length)))
-			}
-		case *proto.DataPacket:
-			c.mu.Lock()
-			stream, ok := c.record[msg.StreamIndex]
-			c.mu.Unlock()
-			if ok {
-				stream.write(msg.Data)
-			}
-		default:
-			//fmt.Printf("%#v\n", msg)
+	var lastErr error
+	for _, s := range servers {
+		if s.localname != "" && localname != s.localname {
+			continue
 		}
-	}
-	c.c.Open(conn)
+		conn, err := net.Dial(s.protocol, s.addr)
+		if err != nil {
+			lastErr = err
+			continue
+		}
 
-	cookiePath := os.Getenv("HOME") + "/.config/pulse/cookie"
-	if path, ok := os.LookupEnv("PULSE_COOKIE"); ok {
-		cookiePath = path
-	}
+		c := &Client{conn: conn}
+		c.playback = make(map[uint32]*PlaybackStream)
+		c.record = make(map[uint32]*RecordStream)
+		c.c.Callback = func(msg interface{}) {
+			switch msg := msg.(type) {
+			case *proto.Request:
+				c.mu.Lock()
+				stream, ok := c.playback[msg.StreamIndex]
+				c.mu.Unlock()
+				if ok {
+					c.c.Send(msg.StreamIndex, stream.buffer(int(msg.Length)))
+				}
+			case *proto.DataPacket:
+				c.mu.Lock()
+				stream, ok := c.record[msg.StreamIndex]
+				c.mu.Unlock()
+				if ok {
+					stream.write(msg.Data)
+				}
+			default:
+				//fmt.Printf("%#v\n", msg)
+			}
+		}
+		c.c.Open(conn)
 
-	cookie, err := ioutil.ReadFile(cookiePath)
-	if err != nil {
-		if !os.IsNotExist(err) {
+		cookiePath := os.Getenv("HOME") + "/.config/pulse/cookie"
+		if path, ok := os.LookupEnv("PULSE_COOKIE"); ok {
+			cookiePath = path
+		}
+
+		cookie, err := ioutil.ReadFile(cookiePath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				c.conn.Close()
+				lastErr = err
+				continue
+			}
+			// If the server is launched with auth-anonymous=1,
+			// any 256 bytes cookie will be accepted.
+			cookie = make([]byte, 256)
+		}
+		var authReply proto.AuthReply
+		err = c.c.Request(
+			&proto.Auth{
+				Version: c.c.Version(),
+				Cookie:  cookie,
+			}, &authReply)
+		if err != nil {
 			c.conn.Close()
-			return nil, err
+			lastErr = err
+			continue
 		}
-		// If the server is launched with auth-anonymous=1,
-		// any 256 bytes cookie will be accepted.
-		cookie = make([]byte, 256)
-	}
-	var authReply proto.AuthReply
-	err = c.c.Request(
-		&proto.Auth{
-			Version: c.c.Version(),
-			Cookie:  cookie,
-		}, &authReply)
-	if err != nil {
-		c.conn.Close()
-		return nil, err
-	}
-	c.c.SetVersion(authReply.Version)
+		c.c.SetVersion(authReply.Version)
 
-	err = c.c.Request(&proto.SetClientName{map[string]string{
-		"media.name":                 "go audio",
-		"application.name":           path.Base(os.Args[0]),
-		"application.process.id":     fmt.Sprintf("%d", os.Getpid()),
-		"application.process.binary": os.Args[0],
-		"window.x11.display":         os.Getenv("DISPLAY"),
-	}}, &proto.SetClientNameReply{})
-	if err != nil {
-		c.conn.Close()
-		return nil, err
-	}
+		err = c.c.Request(&proto.SetClientName{map[string]string{
+			"media.name":                 "go audio",
+			"application.name":           path.Base(os.Args[0]),
+			"application.process.id":     fmt.Sprintf("%d", os.Getpid()),
+			"application.process.binary": os.Args[0],
+			"window.x11.display":         os.Getenv("DISPLAY"),
+		}}, &proto.SetClientNameReply{})
+		if err != nil {
+			c.conn.Close()
+			lastErr = err
+			continue
+		}
 
-	return c, nil
+		return c, nil
+	}
+	return nil, fmt.Errorf("connections failed: %v", lastErr)
 }
 
 func (c *Client) Close() {

--- a/serverstr.go
+++ b/serverstr.go
@@ -1,0 +1,49 @@
+package pulse
+
+import (
+	"strings"
+)
+
+type serverString struct {
+	localname string
+	protocol  string
+	addr      string
+}
+
+func parseServerString(str string) []serverString {
+	s := strings.Fields(str)
+	var result []serverString
+	for _, s := range s {
+		var server serverString
+		if s[0] == '{' {
+			end := strings.IndexByte(s, '}')
+			server.localname = s[1:end]
+			s = s[end+1:]
+		}
+		switch {
+		case len(s) == 0:
+			// no server string
+			continue
+		case s[0] == '/':
+			server.protocol = "unix"
+			server.addr = s
+		case strings.HasPrefix(s, "unix:"):
+			server.protocol = "unix"
+			server.addr = s[5:]
+		case strings.HasPrefix(s, "tcp6:"):
+			server.protocol = "tcp6"
+			server.addr = s[5:]
+		case strings.HasPrefix(s, "tcp4:"):
+			server.protocol = "tcp4"
+			server.addr = s[5:]
+		case strings.HasPrefix(s, "tcp:"):
+			server.protocol = "tcp"
+			server.addr = s[4:]
+		default:
+			// invalid server string
+			continue
+		}
+		result = append(result, server)
+	}
+	return result
+}

--- a/serverstr_test.go
+++ b/serverstr_test.go
@@ -1,0 +1,51 @@
+package pulse
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseServerString(t *testing.T) {
+	cases := []struct {
+		input  string
+		result []serverString
+	}{
+		{
+			"/path/to/socket",
+			[]serverString{
+				{"", "unix", "/path/to/socket"},
+			},
+		},
+		{
+			"tcp4:host:port",
+			[]serverString{
+				{"", "tcp4", "host:port"},
+			},
+		},
+		{
+			"tcp6:host:port",
+			[]serverString{
+				{"", "tcp6", "host:port"},
+			},
+		},
+		{
+			"tcp:address:port",
+			[]serverString{
+				{"", "tcp", "address:port"},
+			},
+		},
+		{
+			"{somewhere}/path/to/socket tcp:address:port",
+			[]serverString{
+				{"somewhere", "unix", "/path/to/socket"},
+				{"", "tcp", "address:port"},
+			},
+		},
+	}
+	for _, c := range cases {
+		s := parseServerString(c.input)
+		if !reflect.DeepEqual(c.result, s) {
+			t.Errorf("Expected parse result: %+v, but got: %+v", c.result, s)
+		}
+	}
+}


### PR DESCRIPTION
Set PULSE_SERVER and PULSE_COOKIE environment variables to specify
server and cookie location. If cookie file doesn't exist, try
anonymous auth.
This commit also adds support for TCP socket connection.