### PR TITLE
Initialize the FormatInfo.Properties map before filling it.

### DIFF
--- a/proto/reader.go
+++ b/proto/reader.go
@@ -202,6 +202,7 @@ func (p *ProtocolReader) value(i interface{}, version Version) {
 					p.byte() // B
 					fi[i].Encoding = p.byte()
 					p.byte() // P
+					fi[i].Properties = make(map[string]string)
 					p.propList(fi[i].Properties)
 				}
 			} else {


### PR DESCRIPTION
The demo/play program failed to start because the map in the FormatInfo.Properties field was not initialized before it was filled.