### PR TITLE
Add a callback that is notified if the client connection is closed

### DIFF
--- a/proto/client.go
+++ b/proto/client.go
@@ -71,6 +71,11 @@ func (c *Client) Request(req RequestArgs, rpl Reply) error {
 	c.nextID++
 	c.awaitReply[tag] = AwaitReply{rpl, reply}
 	c.replyM.Unlock()
+	defer func() {
+		c.replyM.Lock()
+		delete(c.awaitReply, tag)
+		c.replyM.Unlock()
+	}()
 
 	var buf bytes.Buffer
 	w := ProtocolWriter{w: &buf}

--- a/proto/client.go
+++ b/proto/client.go
@@ -114,7 +114,7 @@ func (c *Client) readLoop() {
 		flags := c.r.uint32()
 		_, _ = offset, flags
 		if c.r.err != nil {
-			c.error(c.err)
+			c.error(c.r.err)
 			return
 		}
 		if index == 0xFFFFFFFF {

--- a/proto/client.go
+++ b/proto/client.go
@@ -213,7 +213,9 @@ func (c *Client) error(err error) {
 		ch <- err
 	}
 	if errors.Is(err, io.EOF) && (c.OnConnectionClosed != nil) {
-		c.OnConnectionClosed()
+		go func() {
+			c.OnConnectionClosed()
+		}()
 	}
 }
 

--- a/proto/client.go
+++ b/proto/client.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -20,7 +21,8 @@ type Client struct {
 
 	send chan send
 
-	Callback func(interface{})
+	Callback           func(interface{})
+	OnConnectionClosed func()
 }
 
 type send struct {
@@ -204,6 +206,9 @@ func (c *Client) error(err error) {
 	c.replyM.Unlock()
 	for _, ch := range ch {
 		ch <- err
+	}
+	if errors.Is(err, io.EOF) && (c.OnConnectionClosed != nil) {
+		c.OnConnectionClosed()
 	}
 }
 

--- a/proto/client.go
+++ b/proto/client.go
@@ -58,7 +58,7 @@ type AwaitReply struct {
 
 func (c *Client) Request(req RequestArgs, rpl Reply) error {
 	if rpl != nil && req.command() != rpl.IsReplyTo() {
-		panic("pulse: wrong reply type")
+		return fmt.Errorf("pulse: wrong reply type, got %d but expected %d", rpl.IsReplyTo(), req.command())
 	}
 
 	reply := make(chan error, 1)


### PR DESCRIPTION
The client connection is closed e.g. when you restart pulseaudio (`pulseaudio -k`) after a change of the configuration. In my application I want to try a reconnect in this case. So I added a callback to proto.Client that is notified if the client connection is closed.

I also fixed a bug in the error handler of the read loop: since old requests were not removed from the `awaitReply` map once their reply was received, the method `Client.error` got stuck when trying to write the error to a stale entry in the `awaitReply` map.