### PR TITLE
Fix deadlock after underflow

### DIFF
--- a/.github/integration-test/integration_test.go
+++ b/.github/integration-test/integration_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/jfreymuth/pulse"
 )
 
-func TestIntegration(t *testing.T) {
+func TestLoopback(t *testing.T) {
 	var buf []int16
 
 	// Dummy loopback doesn't start immediately sometimes.
 	// Retry a few times.
 	for retry := 0; retry < 3; retry++ {
+		buf = nil
 		c, err := pulse.NewClient()
 		if err != nil {
 			t.Fatal(err)
@@ -32,20 +33,8 @@ func TestIntegration(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		var cnt uint32
 		playback, err := c.NewPlayback(
-			pulse.Int16Reader(func(out []int16) (int, error) {
-				// Play rectangular wave
-				for i, _ := range out {
-					if cnt%16 < 8 {
-						out[i] = 1000
-					} else {
-						out[i] = -1000
-					}
-					cnt++
-				}
-				return len(out), nil
-			}),
+			pulse.Int16Reader((&sampleWaveGenerator{}).generate),
 			pulse.PlaybackBufferSize(256),
 		)
 		if err != nil {
@@ -60,12 +49,109 @@ func TestIntegration(t *testing.T) {
 		playback.Stop()
 		playback.Drain()
 
-		if len(buf) > 256 {
+		if len(buf) > 1024 {
 			break
 		}
 	}
+	assertSamples(t, buf)
+}
 
-	if len(buf) < 256 {
+func TestUnderflow(t *testing.T) {
+	var buf []int16
+
+	// Dummy loopback doesn't start immediately sometimes.
+	// Retry a few times.
+	for retry := 0; retry < 3; retry++ {
+		buf = nil
+		c, err := pulse.NewClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer c.Close()
+
+		unblocked := make(chan struct{})
+		enableRecord := make(chan struct{})
+
+		record, err := c.NewRecord(
+			pulse.Int16Writer(func(in []int16) (int, error) {
+				select {
+				case <-enableRecord:
+					buf = append(buf, in...)
+				default:
+				}
+				return len(in), nil
+			}),
+			pulse.RecordBufferFragmentSize(256),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var initPlay bool
+		gen := &sampleWaveGenerator{}
+		playback, err := c.NewPlayback(
+			pulse.Int16Reader(func(out []int16) (int, error) {
+				// Return the first buffer immediately to unblock Start()
+				if initPlay {
+					<-unblocked
+				}
+				initPlay = true
+				return gen.generate(out)
+			}),
+			pulse.PlaybackBufferSize(256),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		record.Start()
+		playback.Start()
+
+		time.Sleep(500 * time.Millisecond)
+
+		// Unblock reader
+		close(unblocked)
+
+		// Skip data during block
+		time.Sleep(500 * time.Millisecond)
+		close(enableRecord)
+
+		time.Sleep(time.Second)
+
+		if !playback.Underflow() {
+			t.Error("Playback should be marked underflow if reader had been blocked")
+		}
+
+		record.Stop()
+		playback.Stop()
+		playback.Drain()
+
+		if len(buf) > 1024 {
+			break
+		}
+	}
+	assertSamples(t, buf)
+}
+
+type sampleWaveGenerator struct {
+	cnt uint32
+}
+
+func (g *sampleWaveGenerator) generate(out []int16) (int, error) {
+	// Play rectangular wave
+	for i, _ := range out {
+		if g.cnt%16 < 8 {
+			out[i] = 1000
+		} else {
+			out[i] = -1000
+		}
+		g.cnt++
+	}
+	return len(out), nil
+}
+
+func assertSamples(t *testing.T, buf []int16) {
+	if len(buf) < 1024 {
 		t.Fatalf("Could not record enough number of the samples. (%d)", len(buf))
 	}
 

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 			c.mu.Lock()
 			stream, ok := c.playback[msg.StreamIndex]
 			c.mu.Unlock()
-			if ok && stream.state == running {
+			if ok && stream.state == running && !stream.underflow {
 				stream.started <- true
 			}
 		case *proto.Underflow:
@@ -82,7 +82,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 			c.mu.Unlock()
 			if ok {
 				if stream.state == running {
-					stream.state = underflow
+					stream.underflow = true
 				}
 			}
 		case *proto.ConnectionClosed:

--- a/stream.go
+++ b/stream.go
@@ -6,7 +6,6 @@ const (
 	idle streamState = iota
 	running
 	paused
-	underflow
 	closed
 	serverLost
 )


### PR DESCRIPTION
Pulseaudio sends Started message after an underflow condition is resumed.
Sending true to stream.started channel caused deadlock.