### PR TITLE
expose sink-index-input from playback stream

### DIFF
--- a/playback.go
+++ b/playback.go
@@ -206,6 +206,10 @@ func (p *PlaybackStream) StreamIndex() uint32 {
 	return p.index
 }
 
+func (p *PlaybackStream) StreamInputIndex() uint32 {
+	return p.createReply.SinkInputIndex
+}
+
 // A PlaybackOption supplies configuration when creating streams.
 type PlaybackOption func(*PlaybackStream)
 


### PR DESCRIPTION
Needed to change the volume afterwards like this (working)
````
	vols := make(proto.ChannelVolumes, 2)

	vols[0] = linearVolume
	vols[1] = linearVolume

	err := s.client.RawRequest(&proto.SetSinkInputVolume{
		SinkInputIndex: s.stream.StreamInputIndex(),
		ChannelVolumes: vols,
	}, nil)
````