### PR TITLE
Add volume constants and fix percentage in subscription demo

### DIFF
--- a/demo/subscription/main.go
+++ b/demo/subscription/main.go
@@ -56,7 +56,7 @@ func main() {
 			acc += int64(vol)
 		}
 		acc /= int64(len(repl.ChannelVolumes))
-		pct := float64(acc) / float64(repl.BaseVolume) * 100.0
+		pct := float64(acc) / float64(proto.VolumeNorm) * 100.0
 		log.Printf("%s volume: %.0f%%", *sinkName, pct)
 	}
 }

--- a/proto/types.go
+++ b/proto/types.go
@@ -1,5 +1,7 @@
 package proto
 
+import "math"
+
 const Undefined = 0xFFFFFFFF
 
 const (
@@ -61,6 +63,17 @@ type Time struct {
 }
 
 type Volume uint32
+
+const (
+	// Muted (minimal valid) volume (0%, -inf dB)
+	VolumeMuted Volume = 0
+	// Normal volume (100%, 0 dB)
+	VolumeNorm Volume = 0x10000
+	// Maximum valid volume we can store.
+	VolumeMax Volume = math.MaxUint32 / 2
+	// Special 'invalid' volume.
+	VolumeInvalid Volume = math.MaxUint32
+)
 
 type FormatInfo struct {
 	Encoding   byte


### PR DESCRIPTION
Volume constants and their comments are taken verbatim from PulseAudio.

As of percentage calculation, 100% volume is supposed to be `PA_VOLUME_NORM`, not base volume (see commit message for details).