### PR TITLE
Allow requests to time out when no reply received

### DIFF
--- a/proto/connect.go
+++ b/proto/connect.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // Connect connects to the pulse server.
@@ -29,7 +30,9 @@ func Connect(server string) (*Client, net.Conn, error) {
 	if len(sstr) == 0 {
 		return nil, nil, errors.New("pulseaudio: no valid server")
 	}
-	c := &Client{}
+	c := &Client{
+		timeout: 1 * time.Second,
+	}
 
 	localname, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
Currently it's possible for a request to block forever waiting for a response. I'm not certain under what circumstances this happens, but it has happened frequently enough for me in a simple application that monitors and adjusts source/sink volume/mute that this seems warranted to avoid blocking the whole application indefinitely.