### PR TITLE
fix(proto): break early when read error occurs

### DIFF
--- a/proto/client.go
+++ b/proto/client.go
@@ -232,7 +232,7 @@ func (c *Client) error(err error) {
 
 func (c *Client) parseInfoList(value interface{}, length int) {
 	start := c.r.pos
-	for c.r.pos-start < length {
+	for c.r.err == nil && c.r.pos-start < length {
 		switch value := value.(type) {
 		case *GetSinkInfoListReply:
 			var v GetSinkInfoReply

--- a/proto/reader.go
+++ b/proto/reader.go
@@ -179,6 +179,10 @@ func (p *ProtocolReader) value(i interface{}, version Version) {
 	v := reflect.ValueOf(i).Elem()
 	t := v.Type()
 	for i := 0; i < v.NumField(); i++ {
+		if p.err != nil {
+			return
+		}
+
 		f := v.Field(i)
 
 		if tag := string(t.Field(i).Tag); tag != "" {


### PR DESCRIPTION
Because the read methods of ProtocolReader does not return error, the timing of the error check will occur at the end of a full operation. This makes it possible to read endlessly when a read error occurs during methods like parseInfoList().

Break early when reading the conn in a loop to avoid this.

Fixes https://github.com/jfreymuth/pulse/issues/30