### PR TITLE
perf(proto): minimize allocation of ProtocolReader

### DIFF
--- a/proto/client.go
+++ b/proto/client.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -46,7 +47,7 @@ func (c *Client) SetTimeout(t time.Duration) {
 func (c *Client) Open(rw io.ReadWriter) {
 	//debug, _ := os.Create("debug")
 	//c.r.r = io.TeeReader(rw, debug)
-	c.r.r = rw
+	c.r.r = bufio.NewReader(rw)
 	c.w.w = rw
 	c.v = Version(32)
 
@@ -205,11 +206,11 @@ func (c *Client) readLoop() {
 				}
 			}
 		} else {
+			buf := c.r.tmpbytes(int(length))
 			if c.Callback != nil {
-				buf := c.r.tmpbytes(int(length))
 				c.Callback(&DataPacket{index, buf})
 			}
-			c.r.advance(int(length))
+			c.r.pos += int(length)
 		}
 	}
 }

--- a/proto/reader.go
+++ b/proto/reader.go
@@ -84,7 +84,7 @@ func (p *ProtocolReader) string() string {
 
 		p.buf.Write(frag)
 
-		if p.buf.Len() > 1024 {
+		if p.buf.Len() > maxLength {
 			p.setErr(ErrProtocolError)
 			return ""
 		}

--- a/proto/reader_test.go
+++ b/proto/reader_test.go
@@ -1,0 +1,257 @@
+package proto
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestProtocolReaderUint32(t *testing.T) {
+	r := ProtocolReader{
+		r: bufio.NewReader(prepareUint32Buf()),
+	}
+
+	for i := uint32(0); i < 1000; i++ {
+		d := r.uint32()
+		if r.err != nil {
+			t.Errorf("expecting no error, got %v", r.err)
+			return
+		}
+
+		if d != i {
+			t.Errorf("expecting read %d, got %d", i, d)
+			return
+		}
+	}
+
+	if r.pos != 4000 {
+		t.Errorf("expecting final pos %d, got %d", 4000, r.pos)
+		return
+	}
+}
+
+func BenchmarkProtocolReaderUint32(b *testing.B) {
+	buf := prepareUint32Buf().Bytes()
+
+	var r ProtocolReader
+
+	reader := bufio.NewReader(bytes.NewReader(buf))
+	r.r = reader
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		reader.Reset(bytes.NewReader(buf))
+		for i := uint32(0); i < 1000; i++ {
+			d := r.uint32()
+			if r.err != nil {
+				b.Errorf("expecting no error, got %v", r.err)
+				return
+			}
+
+			if d != i {
+				b.Errorf("expecting read %d, got %d", i, d)
+				return
+			}
+		}
+	}
+}
+
+func prepareUint32Buf() *bytes.Buffer {
+	var buf bytes.Buffer
+
+	for i := uint32(0); i < 1000; i++ {
+		err := binary.Write(&buf, binary.BigEndian, i)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return &buf
+}
+
+func prepareUint64Buf() *bytes.Buffer {
+	var buf bytes.Buffer
+
+	for i := uint64(0); i < 1000; i++ {
+		err := binary.Write(&buf, binary.BigEndian, i)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return &buf
+}
+
+func TestProtocolReaderUint64(t *testing.T) {
+	r := ProtocolReader{
+		r: bufio.NewReader(prepareUint64Buf()),
+	}
+
+	for i := uint64(0); i < 1000; i++ {
+		d := r.uint64()
+		if r.err != nil {
+			t.Errorf("expecting no error, got %v", r.err)
+			return
+		}
+
+		if d != i {
+			t.Errorf("expecting read %d, got %d", i, d)
+			return
+		}
+	}
+
+	if r.pos != 8000 {
+		t.Errorf("expecting final pos %d, got %d", 8000, r.pos)
+		return
+	}
+}
+
+func prepareByteBuf() *bytes.Buffer {
+	var buf bytes.Buffer
+
+	for i := byte(0); i < 255; i++ {
+		err := binary.Write(&buf, binary.BigEndian, i)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return &buf
+}
+
+func TestProtocolReaderByte(t *testing.T) {
+	r := ProtocolReader{
+		r: bufio.NewReader(prepareByteBuf()),
+	}
+
+	for i := byte(0); i < 255; i++ {
+		d := r.byte()
+		if r.err != nil {
+			t.Errorf("expecting no error, got %v", r.err)
+			return
+		}
+
+		if d != i {
+			t.Errorf("expecting read %d, got %d", i, d)
+			return
+		}
+	}
+
+	if r.pos != 255 {
+		t.Errorf("expecting final pos %d, got %d", 255, r.pos)
+		return
+	}
+}
+
+func TestProtocolReaderBytes(t *testing.T) {
+	r := ProtocolReader{
+		r: bufio.NewReader(prepareUint32Buf()),
+	}
+
+	b := make([]byte, 4000)
+
+	r.bytes(b)
+
+	for i := uint32(0); i < 1000; i++ {
+		u := binary.BigEndian.Uint32(b[i*4 : (i+1)*4])
+
+		if u != i {
+			t.Errorf("expecting %d, got %d", i, u)
+			return
+		}
+	}
+
+	if r.pos != 4000 {
+		t.Errorf("expecting final pos %d, got %d", 4000, r.pos)
+		return
+	}
+}
+
+func TestProtocolReaderTmpBytes(t *testing.T) {
+	r := ProtocolReader{
+		r: bufio.NewReader(prepareUint32Buf()),
+	}
+
+	b := r.tmpbytes(4000)
+
+	for i := uint32(0); i < 1000; i++ {
+		u := binary.BigEndian.Uint32(b[i*4 : (i+1)*4])
+
+		if u != i {
+			t.Errorf("expecting %d, got %d", i, u)
+			return
+		}
+	}
+
+	if r.pos != 0 {
+		t.Errorf("expecting final pos %d, got %d", 0, r.pos)
+		return
+	}
+}
+
+func TestProtocolReaderString(t *testing.T) {
+	original := "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\x00"
+	r := ProtocolReader{
+		r: bufio.NewReader(strings.NewReader(original)),
+	}
+
+	s := r.string()
+
+	if s != original[:len(original)-1] {
+		t.Errorf("expecting %s, got %s", s, original[:len(original)-1])
+		return
+	}
+
+	if r.pos != len(original) {
+		t.Errorf("expecting final pos %d, got %d", len(original), r.pos)
+		return
+	}
+}
+
+func prepareXBuf() *bytes.Buffer {
+	var buf bytes.Buffer
+
+	err := binary.Write(&buf, binary.BigEndian, uint32(1000))
+	if err != nil {
+		panic(err)
+	}
+
+	for i := uint32(0); i < 250; i++ {
+		err := binary.Write(&buf, binary.BigEndian, i)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return &buf
+}
+
+func TestProtocolReaderX(t *testing.T) {
+	r := ProtocolReader{
+		r: bufio.NewReader(prepareXBuf()),
+	}
+
+	b := r.x()
+
+	if len(b) != 1000 {
+		t.Errorf("expecting length of %d, got %d", 1000, len(b))
+		return
+	}
+
+	for i := uint32(0); i < 250; i++ {
+		u := binary.BigEndian.Uint32(b[i*4 : (i+1)*4])
+
+		if u != i {
+			t.Errorf("expecting %d, got %d", i, u)
+			return
+		}
+	}
+
+	if r.pos != 1004 {
+		t.Errorf("expecting final pos %d, got %d", 1004, r.pos)
+		return
+	}
+}


### PR DESCRIPTION
ProtocolReader uses an internal buffer for reading, but it is constantly
shrinked from the start side of the slice by `advance()`,
so the underlying array isnot reused.
When the intenal buffer run out of space, the `fill()` will make a new
slice. This adds GC pressure when reading audio streams.

This commit does the following to reduce memory allocation.

- Wrap the underlying *net.Conn with a bufio.Reader. It has a
  fixed-size buffer so the number of syscalls could be reduced.
  It also reuses its buffer so there is no need to handle that
  ourselves. bufio.Reader also comes with handy methods to deal with
  null-terminated strings.

- The reader keep two pieces of memory. One is a [8]byte for temporary storing
  integral types. The other is a bytes.Buffer for variable length items
  like strings and byte arrays. This is always reset when reading new
  data, so new memory is only allocated when reading in things larger than its
  size.


