### PR TITLE
Fix data races in stream.state

### DIFF
--- a/client.go
+++ b/client.go
@@ -86,7 +86,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 			c.mu.Lock()
 			stream, ok := c.playback[msg.StreamIndex]
 			c.mu.Unlock()
-			if ok && stream.state == running && !stream.underflow {
+			if ok && stream.state.Load() == running && !stream.underflow {
 				stream.started <- true
 			}
 		case *proto.Underflow:
@@ -94,7 +94,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 			stream, ok := c.playback[msg.StreamIndex]
 			c.mu.Unlock()
 			if ok {
-				if stream.state == running {
+				if stream.state.Load() == running {
 					stream.underflow = true
 				}
 			}
@@ -103,11 +103,11 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 			for _, p := range c.playback {
 				close(p.request)
 				p.err = ErrConnectionClosed
-				p.state = serverLost
+				p.state.Store(serverLost)
 			}
 			for _, r := range c.record {
 				r.err = ErrConnectionClosed
-				r.state = serverLost
+				r.state.Store(serverLost)
 			}
 			c.playback = make(map[uint32]*PlaybackStream)
 			c.record = make(map[uint32]*RecordStream)

--- a/stream.go
+++ b/stream.go
@@ -1,9 +1,7 @@
 package pulse
 
-type streamState int
-
 const (
-	idle streamState = iota
+	idle uint32 = iota
 	running
 	paused
 	closed


### PR DESCRIPTION
PlaybackStream and RecordStream had both a 'state' variable that got read and updated from different goroutines. This is a data race, and shows up when running with the -race flag.

I've tried to make the code a bit less racy, and used an atomic value to fix the warnings about the race condition. I'm still not 100% convinced this fixes all races though.

(Draft, because it conflicts with #35. I'll rebase once that PR gets merged or closed).