### PR TITLE
Fix(parseServersString): Parse PULSE_SERVER-s without protocol prefixes

### DIFF
--- a/proto/connect.go
+++ b/proto/connect.go
@@ -13,6 +13,14 @@ import (
 	"time"
 )
 
+const defaultPulseAudioTCPPort = uint16(4713)
+
+var defaultPulseAudioTCPPortString string
+
+func init() {
+	defaultPulseAudioTCPPortString = fmt.Sprintf("%d", defaultPulseAudioTCPPort)
+}
+
 // Connect connects to the pulse server.
 //
 // For the server string format see
@@ -92,42 +100,64 @@ type serverString struct {
 	addr      string
 }
 
+// See: https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/User/ServerStrings/
 func parseServerString(str string) []serverString {
 	s := strings.Fields(str)
 	var result []serverString
 	for _, s := range s {
-		var server serverString
-		if s[0] == '{' {
-			end := strings.IndexByte(s, '}')
-			server.localname = s[1:end]
-			s = s[end+1:]
-		}
-		switch {
-		case len(s) == 0:
-			// no server string
-			continue
-		case s[0] == '/':
-			server.protocol = "unix"
-			server.addr = s
-		case strings.HasPrefix(s, "unix:"):
-			server.protocol = "unix"
-			server.addr = s[5:]
-		case strings.HasPrefix(s, "tcp6:"):
-			server.protocol = "tcp6"
-			server.addr = s[5:]
-		case strings.HasPrefix(s, "tcp4:"):
-			server.protocol = "tcp4"
-			server.addr = s[5:]
-		case strings.HasPrefix(s, "tcp:"):
-			server.protocol = "tcp"
-			server.addr = s[4:]
-		default:
-			// invalid server string
+		server, ok := parseOneServerString(s)
+		if !ok {
 			continue
 		}
 		result = append(result, server)
 	}
 	return result
+}
+
+func parseOneServerString(s string) (serverString, bool) {
+	var server serverString
+	if s[0] == '{' {
+		end := strings.IndexByte(s, '}')
+		server.localname = s[1:end]
+		s = s[end+1:]
+	}
+	switch {
+	case len(s) == 0:
+		// no server string
+		return serverString{}, false
+	case s[0] == '/':
+		// rule #2
+		server.protocol = "unix"
+		server.addr = s
+	case strings.HasPrefix(s, "unix:"):
+		// rule #2
+		server.protocol = "unix"
+		server.addr = s[5:]
+	case strings.HasPrefix(s, "tcp6:"):
+		// rule #4
+		server.protocol = "tcp6"
+		server.addr = s[5:]
+	case strings.HasPrefix(s, "tcp4:"):
+		// rule #3
+		server.protocol = "tcp4"
+		server.addr = s[5:]
+	case strings.HasPrefix(s, "tcp:"):
+		// rule #3
+		server.protocol = "tcp"
+		server.addr = s[4:]
+	default:
+		// rule #5
+		if _, _, err := net.SplitHostPort(s); err == nil {
+			server.protocol = "tcp"
+			server.addr = s
+		} else {
+			// Adding a default port, because in the doc
+			// it is stated that `gurki` is a valid example...
+			server.protocol = "tcp"
+			server.addr = net.JoinHostPort(s, defaultPulseAudioTCPPortString)
+		}
+	}
+	return server, true
 }
 
 func defaultServerStrings() []serverString {

--- a/proto/serverstr_test.go
+++ b/proto/serverstr_test.go
@@ -35,6 +35,24 @@ func TestParseServerString(t *testing.T) {
 			},
 		},
 		{
+			"gurki",
+			[]serverString{
+				{"", "tcp", "gurki:4713"},
+			},
+		},
+		{
+			"127.0.0.1",
+			[]serverString{
+				{"", "tcp", "127.0.0.1:4713"},
+			},
+		},
+		{
+			"127.0.0.1:1234",
+			[]serverString{
+				{"", "tcp", "127.0.0.1:1234"},
+			},
+		},
+		{
 			"{somewhere}/path/to/socket tcp:address:port",
 			[]serverString{
 				{"somewhere", "unix", "/path/to/socket"},


### PR DESCRIPTION
Improving the parser of the "servers string":

The documentation about `PULSE_SERVER` specifies:
> Otherwise a similar rule applies, but it is left to the resolver whether IPv4 or IPv6 is used for the connection.

And gives an example of a valid server address:
> `gurki`

In this PR I'm making the parser to interpret values like `gurki`, `127.0.0.1` and `gurki:4713` correctly.